### PR TITLE
Implemented loading custom GPT2LMHeadModel from _model_path

### DIFF
--- a/llm_transparency_tool/models/hash_funcs.py
+++ b/llm_transparency_tool/models/hash_funcs.py
@@ -1,0 +1,9 @@
+import transformers
+
+# If you load a new model from _model_path, please add its class here so that Streamlit can cache it
+
+HASH_FUNCS = {
+    transformers.PreTrainedModel: id,
+    transformers.PreTrainedTokenizer: id,
+    transformers.GPT2LMHeadModel: id,
+}

--- a/llm_transparency_tool/models/load_custom_model.py
+++ b/llm_transparency_tool/models/load_custom_model.py
@@ -1,0 +1,49 @@
+import torch
+import transformers
+from transformer_lens import HookedTransformer, HookedTransformerConfig
+from transformer_lens.loading_from_pretrained import convert_gpt2_weights
+
+
+def hf_model_to_hooked_transformer(
+    hf_model: transformers.PreTrainedModel,
+    device: str = "cuda",
+    dtype: torch.dtype = torch.float32,
+) -> HookedTransformer:
+    """
+    Returns a converted HookedTransformer from a HuggingFace model. 
+    Currently, only GPT2LMHeadModel is supported. 
+    However, you can add support for other models by using the following implementation as a reference.
+    """
+    architecture = hf_model.config.architectures[0]
+    hf_config = hf_model.config
+    if architecture == "GPT2LMHeadModel":
+        hooked_cfg = HookedTransformerConfig(
+            d_model=hf_config.n_embd,
+            d_head=hf_config.n_embd // hf_config.n_head,
+            d_mlp=hf_config.n_embd * 4,
+            n_layers=hf_config.n_layer,
+            n_ctx=hf_config.n_ctx,
+            eps=hf_config.layer_norm_epsilon,
+            d_vocab=hf_config.vocab_size,
+            act_fn=hf_config.activation_function,
+            use_attn_scale=True,
+            use_local_attn=False,
+            scale_attn_by_inverse_layer_idx=hf_config.scale_attn_by_inverse_layer_idx,
+            normalization_type="LN",
+            device=device,
+            dtype=dtype,
+        )
+        hooked_weights = convert_gpt2_weights(hf_model, hooked_cfg)
+    else:
+        raise NotImplementedError(
+            f"Loading custom {architecture} is not currently supported"
+        )
+
+    hooked_transformer = HookedTransformer(hooked_cfg)
+    hooked_transformer.load_and_process_state_dict(
+        hooked_weights,
+        fold_ln=False,
+        center_writing_weights=False,
+        center_unembed=False,
+    )
+    return hooked_transformer

--- a/llm_transparency_tool/models/tlens_model.py
+++ b/llm_transparency_tool/models/tlens_model.py
@@ -15,6 +15,7 @@ from jaxtyping import Float, Int
 from typeguard import typechecked
 import streamlit as st
 
+from llm_transparency_tool.models.hash_funcs import HASH_FUNCS
 from llm_transparency_tool.models.load_custom_model import hf_model_to_hooked_transformer
 from llm_transparency_tool.models.transparent_llm import ModelInfo, TransparentLlm
 
@@ -27,13 +28,9 @@ class _RunInfo:
 
 
 @st.cache_resource(
-    max_entries=2,
+    max_entries=1,
     show_spinner=True,
-    hash_funcs={
-        transformers.PreTrainedModel: id,
-        transformers.PreTrainedTokenizer: id,
-        transformers.GPT2LMHeadModel: id
-    }
+    hash_funcs=HASH_FUNCS,
 )
 def load_hooked_transformer(
     model_name: str,

--- a/llm_transparency_tool/server/utils.py
+++ b/llm_transparency_tool/server/utils.py
@@ -56,8 +56,14 @@ def load_model(
     """
     assert _device in possible_devices()
 
+    # Load your custom model supported by TransformerLens, e.g., GPT2LMHeadModel from 
+    # HuggingFace from a file, and its tokenizer
     causal_lm = None
     tokenizer = None
+        
+    if _model_path is not None: 
+        causal_lm = transformers.GPT2LMHeadModel.from_pretrained(_model_path)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(_model_path)
 
     tl_lm = TransformerLensTransparentLlm(
         model_name=model_name,

--- a/llm_transparency_tool/server/utils.py
+++ b/llm_transparency_tool/server/utils.py
@@ -62,7 +62,11 @@ def load_model(
     tokenizer = None
         
     if _model_path is not None: 
-        causal_lm = transformers.GPT2LMHeadModel.from_pretrained(_model_path)
+        causal_lm = transformers.AutoModelForCausalLM.from_pretrained(
+            _model_path, 
+            device_map="cuda" if _device == "gpu" else _device, 
+            torch_dtype=_dtype
+        )
         tokenizer = transformers.AutoTokenizer.from_pretrained(_model_path)
 
     tl_lm = TransformerLensTransparentLlm(


### PR DESCRIPTION
## Summary
While testing my modified GPT2LMHeadModel, I encountered some issues loading the model to the app as a HookedTransformer. Subsequently, I integrated the necessary changes to be able to load this custom model supported by HuggingFace, but, for example, has a different number of layers, heads, etc. compared to the pretrained version. This also allows one to easily integrate other models into the app.

## Implemented Changes
- Added llm_transparency_tool/models/load_custom_model.py
    - It includes a function converting a HuggingFace model, e.g. GPT2LMHeadModel, to a HookedTransformer from transformer_lens.
- Modified llm_transparency_tool/models/tlens_model.py
   - Added an entry to hash_func enabling Streamlit to cache the hf_model variable.
   - Changed max_entries from 1 to 2 to store tlens_model and hf_model in cache together.
    - Now if hf_model is loaded, tlens_model is loaded via the hf_model_to_hooked_transformer function.
- Modified llm_transparency_tool/server/utils.py
    - Made use of _model_path using it for loading GPT2LMHeadModel and its tokenizer. Nevertheless, it doesn't check if the stored model in _model_path is of that class.
