### PR TITLE
Custom Model loading

### DIFF
--- a/config/local.json
+++ b/config/local.json
@@ -5,6 +5,12 @@
     "models": {
         "": null,
 
+        "meta-llama/Meta-Llama-3-8B": null,
+        "meta-llama/Meta-Llama-3-70B": null,
+        "meta-llama/Meta-Llama-3-8B-Instruct": null,
+        "meta-llama/Meta-Llama-3-70B-Instruct": null,
+        "mistral/mixtral-instruct": null,
+
         "gpt2": null,
         "distilgpt2": null,
         "facebook/opt-125m": null,
@@ -24,6 +30,9 @@
 
         "meta-llama/Llama-2-13b-hf": null,
         "meta-llama/Llama-2-13b-chat-hf": null,
+
+        "meta-llama/Llama-2-70b-hf": null,
+        "meta-llama/Llama-2-70b-chat-hf": null,
 
 
         "gpt2-medium": null,

--- a/llm_transparency_tool/models/tlens_model.py
+++ b/llm_transparency_tool/models/tlens_model.py
@@ -180,10 +180,10 @@ class TransformerLensTransparentLlm(TransparentLlm):
             normalized = self._model.ln_final(tdim)
             result = self._model.unembed(normalized)
         else:
-            result = self._model.unembed(tdim)
+            result = self._model.unembed(tdim.to(self.dtype))
         return result[0][0]
 
-    def _get_block(self, layer: int, block_name: str) -> str:
+    def _get_block(self, layer: int, block_name: str) -> torch.Tensor:
         if not self._last_run:
             raise self._run_exception
         return self._last_run.cache[f"blocks.{layer}.{block_name}"]

--- a/llm_transparency_tool/server/app.py
+++ b/llm_transparency_tool/server/app.py
@@ -173,24 +173,25 @@ class App:
 
 
         if not self._config.demo_mode:
-            if self._config.allow_loading_dataset_files:
-                row_f = st_row.row([2, 1], vertical_align="bottom")
-                filename = row_f.text_input("Dataset", value=st.session_state.dataset_file or "")
-                if row_f.button("Load"):
-                    update_dataset(filename)
-            row_s = st_row.row([2, 1], vertical_align="bottom")
-            new_sentence = row_s.text_input("New sentence")
-            new_sentence_added = False
+            with st.sidebar.expander("Dataset", expanded=False):
+                if self._config.allow_loading_dataset_files:
+                    row_f = st_row.row([2, 1], vertical_align="bottom")
+                    filename = row_f.text_input("Dataset", value=st.session_state.dataset_file or "", label_visibility="collapsed")
+                    if row_f.button("Load"):
+                        update_dataset(filename)
+                row_s = st_row.row([2, 1], vertical_align="bottom")
+                new_sentence = row_s.text_area("New sentence", label_visibility="collapsed")
+                new_sentence_added = False
 
-            if row_s.button("Add"):
-                max_len = self._config.max_user_string_length
-                n = len(new_sentence)
-                if max_len is None or n <= max_len:
-                    st.session_state.dataset.append(new_sentence)
-                    new_sentence_added = True
-                    st.session_state.sentence_selector = new_sentence
-                else:
-                    st.warning(f"Sentence length {n} is larger than " f"the configured limit of {max_len}")
+                if row_s.button("Add"):
+                    max_len = self._config.max_user_string_length
+                    n = len(new_sentence)
+                    if max_len is None or n <= max_len:
+                        st.session_state.dataset.append(new_sentence)
+                        new_sentence_added = True
+                        st.session_state.sentence_selector = new_sentence
+                    else:
+                        st.warning(f"Sentence length {n} is larger than " f"the configured limit of {max_len}")
 
         sentences = st.session_state.dataset
         selection = st.selectbox(

--- a/llm_transparency_tool/server/app.py
+++ b/llm_transparency_tool/server/app.py
@@ -407,7 +407,7 @@ class App:
         )
 
         st.dataframe(
-            top_df.style.map(pos_gain_color)
+            top_df.style.applymap(pos_gain_color)
             .background_gradient(
                 axis=0,
                 cmap=logits_color_map(positive_and_negative=n_bottom > 0),
@@ -623,8 +623,8 @@ class App:
 
     def run(self):
 
-        with st.sidebar.expander("About", expanded=True):
-            if self._config.demo_mode:
+        if self._config.demo_mode:
+            with st.sidebar.expander("About", expanded=True):
                 st.caption("""
                     The app is deployed in Demo Mode, thus only predefined models and inputs are available.\n
                     You can still install the app locally and use your own models and inputs.\n

--- a/llm_transparency_tool/server/app.py
+++ b/llm_transparency_tool/server/app.py
@@ -508,11 +508,12 @@ class App:
             model_list = list(self._config.models)
             default_choice = model_list.index(self._config.default_model)
 
-            self.model_name = st.selectbox(
-                "Model",
+            self.supported_model_name = st.selectbox(
+                "Model name",
                 model_list,
                 index=default_choice,
             )
+            self.model_name = st.text_input("Custom model name", value=self.supported_model_name)
 
             if self.model_name:
                 self._stateful_model = load_model(
@@ -520,6 +521,7 @@ class App:
                     _model_path=self._config.models[self.model_name],
                     _device=self.device,
                     _dtype=self.dtype,
+                    supported_model_name=None if not self.supported_model_name else self.supported_model_name,
                 )
                 self.model_key = self.model_name  # TODO maybe something else?
                 self.draw_model_info()

--- a/llm_transparency_tool/server/utils.py
+++ b/llm_transparency_tool/server/utils.py
@@ -49,6 +49,7 @@ def load_model(
     _device: str,
     _model_path: Optional[str] = None,
     _dtype: torch.dtype = torch.float32,
+    supported_model_name: Optional[str] = None,
 ) -> TransparentLlm:
     """
     Returns the loaded model along with its key. The key is just a unique string which
@@ -65,6 +66,7 @@ def load_model(
         tokenizer=tokenizer,
         device=_device,
         dtype=_dtype,
+        supported_model_name=supported_model_name,
     )
 
     return tl_lm


### PR DESCRIPTION
This introduces simplified way of loading custom (including local) models.
As TransformerLens should has predefined rules for model conversion/unification to add hooks, model architecture/config information is often needed. In TransformerLens, working with local models usually means passing the supported model name with `model_name` argument, while also passing manually created `hf_model`.

In our case, we recommend passing two strings (because it's more convenient for UI apps such as LLM Transparency Tool):
- `model_name` : str - the huggingface path / identifier / url
- `supported_model_name` : str - identifier of the model that is supported by TransformerLens

### Usage
1. For example, `meta-llama/Meta-Llama-3.1-8B` and `meta-llama/Meta-Llama-3-8B` models are only different with the parameters, and everything else (architecture, configuration) so the same hooks logic apply for both. At this moment `meta-llama/Meta-Llama-3.1-8B` is not in the list of supported models in TransformerLens <sup>[1]</sup> (though I believe it will be added in very near future) **so if you simply pass `meta-llama/Meta-Llama-3.1-8B` it will not work.**
However, if you pass `supported_model_name="meta-llama/Meta-Llama-3-8B"` it will simply use the hooking logic of `Meta-Llama-3-8B`. BTW, Providing supported_model_name is available from UI as well. 
2. You want to load your finetuned `gpt-2` model, that is available only locally. Then you can provide the local path `model_name="./path_to/my/finetuned_model_dir", supported_model_name="gpt-2"`.


The PR also adds minor changes as well.

<sup>[1]</sup>[https://github.com/TransformerLensOrg/TransformerLens/blob/dd537ba713a943bb5d26b0c84f16174abd6bde5d/transformer_lens/loading_from_pretrained.py#L47]()