### PR TITLE
Bug fix: contribution renormalization correction for FFNs

### DIFF
--- a/llm_transparency_tool/routes/contributions.py
+++ b/llm_transparency_tool/routes/contributions.py
@@ -194,7 +194,10 @@ def apply_threshold_and_renormalize(
     c_blocks = c_blocks * (c_blocks > threshold)
     c_residual = c_residual * (c_residual > threshold)
 
-    denom = c_residual + c_blocks.sum(dim=tuple(range(resid_dims, block_dims)))
+    if bound_dims > 0:
+        denom = c_residual + c_blocks.sum(dim=tuple(range(resid_dims, block_dims)))
+    else:
+        denom = c_residual + c_blocks
     return (
         c_blocks / denom.reshape(denom.shape + (1,) * bound_dims),
         c_residual / denom,


### PR DESCRIPTION
While the `apply_threshold_and_renormalize` method works fine in renormalizing attention contribution scores, it doesn't renormalize correctly for FFNs. The reason is that when using this function for FFNs, the `resid_dims` and `block_dims` are the same. Therefore, in this line in the original code:
https://github.com/facebookresearch/llm-transparency-tool/blob/d8e249e4407b92b6684b52f93b4da169cc1754fa/llm_transparency_tool/routes/contributions.py#L197 
the sum operation receives an empty tuple for the dimensions, leading to the entire `c_blocks` tensor being summed and returning a single scalar value for the whole input length. This causes the returned tensors of this function not to sum up to one for each representation.

In this fix, I’ve added a condition to check if `resid_dims` and `block_dims` are the same, in which case `c_blocks` is added directly to `c_residual` to calculate `denom`.