### PR TITLE
Fix versions of dependencies

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -4,7 +4,7 @@ channels:
   - nvidia
   - conda-forge
 dependencies:
-  - python
+  - python=3.12
   - pytorch
   - pytorch-cuda=11.8
   - nodejs
@@ -14,7 +14,7 @@ dependencies:
       - datasets
       - einops
       - fancy_einsum
-      - jaxtyping
+      - jaxtyping==0.2.25
       - networkx
       - plotly
       - pyinstrument


### PR DESCRIPTION
Fix `jaxtyping` dependency version. Addresses #38 